### PR TITLE
[enhance] Migrate to redhat-nfvpe.prometheus-operator role

### DIFF
--- a/ansible/playbooks/telemetry-monitoring/private/config.yml
+++ b/ansible/playbooks/telemetry-monitoring/private/config.yml
@@ -3,13 +3,22 @@
   hosts: kube-master
   tasks:
     - import_role:
-        name: telemetry.prometheus-operator
+        name: redhat-nfvpe.prometheus-operator
         tasks_from: install.yml
       vars:
         promops_deploy:
           name: sa
           namespace: sa
+          include_alertmanager: false
+          monitor_k8s: false
+          spec:
+            replicas: 1
+          components:
+            - grafana/grafana-credentials.yaml
+            - grafana
+            - prometheus
+            - metrics-consumer
+            - events-consumer
           storage:
             class_name: sa
             size: 2Gi
-


### PR DESCRIPTION
These changes are the start to making the deployment of Prometheus Operator
more dynamic in multiple environments.